### PR TITLE
Change sleep duration to use float for retry

### DIFF
--- a/src/pxweb/_internal/client.py
+++ b/src/pxweb/_internal/client.py
@@ -127,7 +127,7 @@ class Client:
                     f"Response 429, backing off for {retry_after} second(s)"
                 )
 
-                time.sleep(int(retry_after))
+                time.sleep(float(retry_after))
                 # Then continue to do another attempt
                 continue
             else:


### PR DESCRIPTION
int('float inside quotes') does not work. float('float inside quotes') is fine.


Traceback (most recent call last):
  File "/home/bernelius/code/vekstbarometer/indicator-updater/main.py", line 89, in run_indicator
    indicator.run()
    ~~~~~~~~~~~~~^^
  File "/home/bernelius/code/vekstbarometer/indicator-updater/src/base_indicator.py", line 139, in run
    df: pl.DataFrame = self.fetch_data()
                       ~~~~~~~~~~~~~~~^^
  File "/home/bernelius/code/vekstbarometer/indicator-updater/src/base_indicator.py", line 152, in fetch_data
    return self.fetcher_fn()
           ~~~~~~~~~~~~~~~^^
  File "/home/bernelius/code/vekstbarometer/indicator-updater/src/base_indicator.py", line 319, in fetch_from_ssb
    api = PxApi("ssb")
  File "/home/bernelius/code/vekstbarometer/indicator-updater/.venv/lib/python3.14/site-packages/pxweb/api.py", line 74, in __init__
    self._client = Client(
                   ~~~~~~^
        url=API_URLS.get(url, url),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        disable_cache=disable_cache,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )  # Resolve the name if known else assume it's a full URL
    ^
  File "/home/bernelius/code/vekstbarometer/indicator-updater/.venv/lib/python3.14/site-packages/pxweb/_internal/client.py", line 39, in __init__
    configuration = self.call(endpoint="/config", enforce_rate_limit=False)
  File "/home/bernelius/code/vekstbarometer/indicator-updater/.venv/lib/python3.14/site-packages/pxweb/_internal/client.py", line 130, in call
    time.sleep(int(retry_after))
               ~~~^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0.382'